### PR TITLE
statusbar, info view controller, saved animations, constraint issue

### DIFF
--- a/SmartCard/SmartCard/AppDelegate.m
+++ b/SmartCard/SmartCard/AppDelegate.m
@@ -18,7 +18,9 @@
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    
     [Fabric with:@[[Crashlytics class]]];
+    
     return YES;
 }
 

--- a/SmartCard/SmartCard/Base.lproj/Main.storyboard
+++ b/SmartCard/SmartCard/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1713" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
@@ -324,8 +324,38 @@
                                     </textField>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cZl-Vg-EY9">
+                                <rect key="frame" x="270" y="555" width="60" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="60" id="PjM-ga-ZdE"/>
+                                    <constraint firstAttribute="height" constant="30" id="TOf-nP-MRp"/>
+                                </constraints>
+                                <state key="normal" title="Enter"/>
+                            </button>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ovw-zy-uvl">
+                                <rect key="frame" x="150" y="20" width="80" height="80"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="19C-Si-o93"/>
+                                    <constraint firstAttribute="width" constant="80" id="1Iy-sK-Km9"/>
+                                </constraints>
+                            </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fJc-tg-U2I">
+                                <rect key="frame" x="238" y="45" width="30" height="30"/>
+                                <state key="normal" title="Add"/>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZQe-ze-p07">
+                                <rect key="frame" x="0.0" y="20" width="40" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="HVa-3s-0j5"/>
+                                    <constraint firstAttribute="width" constant="40" id="uh3-zf-56J"/>
+                                </constraints>
+                                <state key="normal" title="X"/>
+                                <connections>
+                                    <action selector="dismiss:" destination="Iy0-6k-exG" eventType="touchUpInside" id="foz-xI-kpV"/>
+                                </connections>
+                            </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o9K-Fy-6Dt">
-                                <rect key="frame" x="150" y="181" width="300" height="90"/>
+                                <rect key="frame" x="150" y="199" width="300" height="90"/>
                                 <subviews>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="E-mail" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="765-4B-gdG">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="30"/>
@@ -356,49 +386,76 @@
                                     </textField>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="0uY-UN-l72">
-                                <rect key="frame" x="150" y="279" width="300" height="90"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="a4S-BU-bWL">
+                                <rect key="frame" x="150" y="315" width="300" height="120"/>
                                 <subviews>
-                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="E-mail" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ADv-s4-Gt4">
+                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Street Address" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hEl-VE-OfN">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="30"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="300" id="pWl-ca-0dQ"/>
+                                            <constraint firstAttribute="width" constant="300" id="kdA-40-7fz"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Phone" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Hr-TM-RjY">
+                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Apt or Building Num" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="VJ2-YR-ixz">
                                         <rect key="frame" x="0.0" y="30" width="300" height="30"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="300" id="6Q7-r5-EKG"/>
+                                            <constraint firstAttribute="width" constant="300" id="umS-Xf-IcS"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Website" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Thr-VX-eVP">
+                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="City" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Je6-Gp-3vd">
                                         <rect key="frame" x="0.0" y="60" width="300" height="30"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="300" id="5Qa-0U-akQ"/>
+                                            <constraint firstAttribute="width" constant="300" id="v7K-UD-Cgq"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="5eR-K0-cWS">
+                                        <rect key="frame" x="0.0" y="90" width="300" height="30"/>
+                                        <subviews>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="State" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="roy-Ya-gU6">
+                                                <rect key="frame" x="0.0" y="0.0" width="150" height="30"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Zip Code" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qTo-Zn-Zdn">
+                                                <rect key="frame" x="150" y="0.0" width="150" height="30"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="roy-Ya-gU6" firstAttribute="leading" secondItem="5eR-K0-cWS" secondAttribute="leading" id="KRH-0u-a2s"/>
+                                            <constraint firstItem="qTo-Zn-Zdn" firstAttribute="leading" secondItem="roy-Ya-gU6" secondAttribute="trailing" id="Kh1-TX-F7W"/>
+                                            <constraint firstItem="qTo-Zn-Zdn" firstAttribute="leading" secondItem="roy-Ya-gU6" secondAttribute="trailing" id="NXD-uz-cIu"/>
+                                            <constraint firstAttribute="trailing" secondItem="qTo-Zn-Zdn" secondAttribute="trailing" id="hbv-QF-nrX"/>
+                                            <constraint firstItem="qTo-Zn-Zdn" firstAttribute="top" secondItem="5eR-K0-cWS" secondAttribute="top" id="o2M-LD-q0k"/>
+                                            <constraint firstItem="roy-Ya-gU6" firstAttribute="top" secondItem="5eR-K0-cWS" secondAttribute="top" id="wfZ-kB-R6j"/>
+                                        </constraints>
+                                    </stackView>
                                 </subviews>
-                            </stackView>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Address" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hEl-VE-OfN">
-                                <rect key="frame" x="150" y="377" width="300" height="30"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="300" id="kdA-40-7fz"/>
+                                    <constraint firstItem="VJ2-YR-ixz" firstAttribute="leading" secondItem="a4S-BU-bWL" secondAttribute="leading" id="4Hi-Gt-Ucu"/>
+                                    <constraint firstItem="hEl-VE-OfN" firstAttribute="top" secondItem="a4S-BU-bWL" secondAttribute="top" id="5eK-7h-6fe"/>
+                                    <constraint firstAttribute="trailing" secondItem="Je6-Gp-3vd" secondAttribute="trailing" id="6uY-N9-4S4"/>
+                                    <constraint firstItem="Je6-Gp-3vd" firstAttribute="leading" secondItem="a4S-BU-bWL" secondAttribute="leading" id="V05-2l-rqm"/>
+                                    <constraint firstItem="hEl-VE-OfN" firstAttribute="leading" secondItem="a4S-BU-bWL" secondAttribute="leading" id="f4U-S7-Yxl"/>
+                                    <constraint firstItem="Je6-Gp-3vd" firstAttribute="top" secondItem="VJ2-YR-ixz" secondAttribute="bottom" id="ieE-n3-f7s"/>
+                                    <constraint firstAttribute="trailing" secondItem="hEl-VE-OfN" secondAttribute="trailing" id="nA3-52-Hig"/>
+                                    <constraint firstAttribute="trailing" secondItem="VJ2-YR-ixz" secondAttribute="trailing" id="uOm-Yi-xMd"/>
+                                    <constraint firstItem="VJ2-YR-ixz" firstAttribute="top" secondItem="hEl-VE-OfN" secondAttribute="bottom" id="z1A-Rb-kZ5"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
+                            </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="BhS-tm-Z51">
-                                <rect key="frame" x="150" y="415" width="300" height="60"/>
+                                <rect key="frame" x="150" y="469" width="300" height="60"/>
                                 <subviews>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Company" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ef1-Ss-505">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="30"/>
@@ -420,57 +477,25 @@
                                     </textField>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cZl-Vg-EY9">
-                                <rect key="frame" x="270" y="483" width="60" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="60" id="PjM-ga-ZdE"/>
-                                    <constraint firstAttribute="height" constant="30" id="TOf-nP-MRp"/>
-                                </constraints>
-                                <state key="normal" title="Enter"/>
-                            </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ovw-zy-uvl">
-                                <rect key="frame" x="150" y="20" width="80" height="80"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="80" id="19C-Si-o93"/>
-                                    <constraint firstAttribute="width" constant="80" id="1Iy-sK-Km9"/>
-                                </constraints>
-                            </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fJc-tg-U2I">
-                                <rect key="frame" x="238" y="45" width="30" height="30"/>
-                                <state key="normal" title="Add"/>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZQe-ze-p07">
-                                <rect key="frame" x="0.0" y="20" width="40" height="40"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="HVa-3s-0j5"/>
-                                    <constraint firstAttribute="width" constant="40" id="uh3-zf-56J"/>
-                                </constraints>
-                                <state key="normal" title="X"/>
-                                <connections>
-                                    <action selector="dismiss:" destination="Iy0-6k-exG" eventType="touchUpInside" id="foz-xI-kpV"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.71372549019607845" green="0.76078431372549016" blue="0.85098039215686272" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
+                            <constraint firstItem="a4S-BU-bWL" firstAttribute="top" secondItem="o9K-Fy-6Dt" secondAttribute="bottom" constant="26" id="1I5-xd-IfV"/>
                             <constraint firstItem="fJc-tg-U2I" firstAttribute="centerY" secondItem="Ovw-zy-uvl" secondAttribute="centerY" id="2Sx-qg-kNf"/>
-                            <constraint firstItem="0uY-UN-l72" firstAttribute="centerX" secondItem="gn5-rN-jQt" secondAttribute="centerX" id="4Oc-Os-KdA"/>
-                            <constraint firstItem="BhS-tm-Z51" firstAttribute="top" secondItem="hEl-VE-OfN" secondAttribute="bottom" constant="8" id="AR4-j0-KYX"/>
                             <constraint firstItem="cZl-Vg-EY9" firstAttribute="centerX" secondItem="gn5-rN-jQt" secondAttribute="centerX" id="Lmf-8g-wdB"/>
                             <constraint firstItem="ZQe-ze-p07" firstAttribute="leading" secondItem="gn5-rN-jQt" secondAttribute="leading" id="Mcv-vf-jZe"/>
-                            <constraint firstItem="o9K-Fy-6Dt" firstAttribute="top" secondItem="Tyw-nr-sgf" secondAttribute="bottom" constant="8" id="NTg-Oq-aTR"/>
+                            <constraint firstItem="o9K-Fy-6Dt" firstAttribute="top" secondItem="Tyw-nr-sgf" secondAttribute="bottom" constant="26" id="NTg-Oq-aTR"/>
                             <constraint firstItem="fJc-tg-U2I" firstAttribute="leading" secondItem="Ovw-zy-uvl" secondAttribute="trailing" constant="8" id="OGS-42-Z1N"/>
-                            <constraint firstItem="0uY-UN-l72" firstAttribute="top" secondItem="o9K-Fy-6Dt" secondAttribute="bottom" constant="8" id="PUO-IZ-c1W"/>
                             <constraint firstItem="Ovw-zy-uvl" firstAttribute="leading" secondItem="Tyw-nr-sgf" secondAttribute="leading" id="Q12-5w-hzR"/>
                             <constraint firstItem="Tyw-nr-sgf" firstAttribute="top" secondItem="Ovw-zy-uvl" secondAttribute="bottom" constant="13" id="Rdf-j8-EM1"/>
                             <constraint firstItem="Ovw-zy-uvl" firstAttribute="top" secondItem="wSR-rJ-Mkt" secondAttribute="bottom" id="RuM-jG-uGS"/>
-                            <constraint firstItem="hEl-VE-OfN" firstAttribute="top" secondItem="0uY-UN-l72" secondAttribute="bottom" constant="8" id="WRr-I1-4jy"/>
                             <constraint firstItem="ZQe-ze-p07" firstAttribute="top" secondItem="gn5-rN-jQt" secondAttribute="top" constant="20" id="Yha-kc-GTk"/>
                             <constraint firstItem="o9K-Fy-6Dt" firstAttribute="centerX" secondItem="gn5-rN-jQt" secondAttribute="centerX" id="ceg-Th-Bkd"/>
                             <constraint firstItem="Tyw-nr-sgf" firstAttribute="centerX" secondItem="gn5-rN-jQt" secondAttribute="centerX" id="eQG-WU-zRT"/>
-                            <constraint firstItem="hEl-VE-OfN" firstAttribute="centerX" secondItem="gn5-rN-jQt" secondAttribute="centerX" id="ewm-kX-XeE"/>
                             <constraint firstItem="BhS-tm-Z51" firstAttribute="centerX" secondItem="gn5-rN-jQt" secondAttribute="centerX" id="g1A-Tw-ZqV"/>
-                            <constraint firstItem="cZl-Vg-EY9" firstAttribute="top" secondItem="BhS-tm-Z51" secondAttribute="bottom" constant="8" id="icS-3W-aAX"/>
+                            <constraint firstItem="BhS-tm-Z51" firstAttribute="leading" secondItem="a4S-BU-bWL" secondAttribute="leading" id="hxn-iF-mPX"/>
+                            <constraint firstItem="cZl-Vg-EY9" firstAttribute="top" secondItem="BhS-tm-Z51" secondAttribute="bottom" constant="26" id="icS-3W-aAX"/>
+                            <constraint firstItem="BhS-tm-Z51" firstAttribute="top" secondItem="a4S-BU-bWL" secondAttribute="bottom" constant="34" id="o8J-Lu-xeL"/>
                             <constraint firstItem="o9K-Fy-6Dt" firstAttribute="centerX" secondItem="gn5-rN-jQt" secondAttribute="centerX" id="xiv-ju-Df8"/>
                         </constraints>
                     </view>

--- a/SmartCard/SmartCard/CreateViewController.m
+++ b/SmartCard/SmartCard/CreateViewController.m
@@ -27,6 +27,10 @@
     [super didReceiveMemoryWarning];
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
+
 -(void)setupButton
 {
     self.dismiss.layer.cornerRadius = 20;

--- a/SmartCard/SmartCard/Info.plist
+++ b/SmartCard/SmartCard/Info.plist
@@ -44,6 +44,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/SmartCard/SmartCard/InfoViewController.m
+++ b/SmartCard/SmartCard/InfoViewController.m
@@ -28,6 +28,9 @@
     [super didReceiveMemoryWarning];
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
 
 
 - (IBAction)dismiss:(UIButton *)sender {

--- a/SmartCard/SmartCard/ShareViewController.m
+++ b/SmartCard/SmartCard/ShareViewController.m
@@ -27,6 +27,10 @@
     [super didReceiveMemoryWarning];
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
+
 
 - (IBAction)dismissButton:(id)sender
 {

--- a/SmartCard/SmartCard/TemplateViewController.m
+++ b/SmartCard/SmartCard/TemplateViewController.m
@@ -33,6 +33,10 @@
     [super didReceiveMemoryWarning];
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
+
 -(void)setupButton
 {
     self.dismiss.layer.cornerRadius = 20;

--- a/SmartCard/SmartCard/ViewController.m
+++ b/SmartCard/SmartCard/ViewController.m
@@ -21,21 +21,25 @@
 
 @property (weak, nonatomic) IBOutlet UICollectionView *savedCollectionView;
 
+@property (nonatomic) BOOL isSavedShowing;
+
 @end
 
 @implementation ViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    [self setUpHeightConstrains];
 }
 
 -(void)viewDidAppear:(BOOL)animated{
     [super viewDidAppear:animated];
-    
-    [self setUpHeightConstrains];
     [self setupCollectionView];
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
 
 
 - (void)didReceiveMemoryWarning {
@@ -46,6 +50,7 @@
 -(void)setUpHeightConstrains{
     _createHeight.constant = self.view.frame.size.height / 2;
     _savedHeight.constant = self.view.frame.size.height / 2;
+    self.isSavedShowing = NO;
 }
 
 -(void)setupCollectionView
@@ -63,13 +68,16 @@
 }
 
 -(void)animateConstraints{
-    [UIView animateWithDuration:1.0 delay:0.2 options:UIViewAnimationOptionCurveEaseIn animations:^{
-        
-        _createHeight.constant = 60.0;
+    if (self.isSavedShowing) {
+        [self setUpHeightConstrains];
+    } else {
+        _createHeight.constant = 0.0;
         _savedHeight.constant = 60.0;
-        
-    } completion:^(BOOL finished) {
-        //
+        self.isSavedShowing = YES;
+    }
+    
+    [UIView animateWithDuration:1.0 animations:^{
+        [self.view layoutIfNeeded];
     }];
 }
 


### PR DESCRIPTION
Removed status bar from all view controllers. This must be done manually, so if we add in another VC, you'll need to add in the perfersStatusBarHidden block. Saved button animates up if hidden and animates down if shown. Info view controller has accurate text fields for Address, and I think I fixed the constraint issue in the debugger.
